### PR TITLE
文字数カウント機能を追加

### DIFF
--- a/gas/package.json
+++ b/gas/package.json
@@ -1,6 +1,7 @@
 {
   "scripts": {
-    "build": "webpack"
+    "build": "webpack",
+    "push": "npm run build && clasp push"
   },
   "dependencies": {
     "@types/google-apps-script": "^1.0.46",

--- a/gas/src/ExecFollow.js
+++ b/gas/src/ExecFollow.js
@@ -34,8 +34,7 @@ export function ExecFollow() {
     // フォローしてスプレッドシートを更新する
     shouldFollowUsers.forEach(user => {
       // フォローする
-      // FollowUser(user.userId)
-      console.log(user)
+      FollowUser(user.userId)
 
       // スプレッドシートを更新する
       const followDate = FormatDate(new Date())

--- a/gas/src/Utilities.js
+++ b/gas/src/Utilities.js
@@ -1,6 +1,5 @@
 import { GetAllData } from "./SpreadSheatHandler"
 import twitter from "twitter-text"
-// const twitter = require('twitter-text');
 
 /**
  * 全体設定から各機能のON/OFFを取得する
@@ -41,9 +40,7 @@ export function IsActive({ startTime, endTime }) {
   if (startTime <= currentTime && currentTime <= endTime) {
     return true
   }
-  else {
-    return false
-  }
+  return false
 }
 
 /**

--- a/gas/src/Utilities.js
+++ b/gas/src/Utilities.js
@@ -15,11 +15,8 @@ export function GetOnOffSetting(key) {
  * 文字数チェック
  * npmモジュール「twitter-text」を使用する
  */
-export function CountText() {
-  const text = "123aaabbbあああいいい"
-  // const count = 23
-  const count = twitter.parseTweet(text)
-  console.log(count)
+export function CountText(text) {
+  return twitter.parseTweet(text).weightedLength
 }
 
 /**

--- a/gas/src/WriteWordCount.js
+++ b/gas/src/WriteWordCount.js
@@ -1,0 +1,34 @@
+import { CountText } from "./Utilities"
+
+export function WriteWordCount(e) {
+
+  // 編集されたシート名を取得する
+  const sheet = e.source.getActiveSheet()
+  const sheetName = sheet.getName()
+
+  // 編集されたシートがツイートでないなら何もしない
+  if (sheetName != "ツイート") {
+    return
+  }
+
+  // 編集された範囲を取得する
+  const { columnStart, columnEnd, rowStart, rowEnd } = e.range
+
+  for (let i = rowStart; i <= rowEnd; i++) {
+    for (let j = columnStart; j <= columnEnd; j++) {
+      // ツイート本文列が編集されていた場合、文字カウント列に文字数を記載する
+      if (j == 2) {
+        const text = sheet.getRange(i, j).getValue()
+        const count = CountText(text)
+        sheet.getRange(i, j + 1).setValue(count)
+      }
+
+      // 文字カウント列が編集されていた場合、ツイート本文列の文字を参照して文字数を記載し直す
+      // if (j == 3) {
+      //   const text = sheet.getRange(i, j - 1).getValue()
+      //   const count = CountText(text)
+      //   sheet.getRange(i, j).setValue(count)
+      // }
+    }
+  }
+}

--- a/gas/src/main.js
+++ b/gas/src/main.js
@@ -3,13 +3,13 @@ import { ExecLike } from "./ExecLike";
 import { ExecRetweet } from "./ExecRetweet";
 import { ExecTweet } from "./ExecTweet";
 import { ExecUnfollow } from "./ExecUnfollow";
-import { CountText } from "./Utilities";
 import { TwitterHandlerTest } from "./TwitterHandler"
+import { WriteWordCount } from "./WriteWordCount"
 
-global.ExecFollow= ExecFollow
+global.ExecFollow = ExecFollow
 global.ExecLike = ExecLike
 global.ExecRetweet = ExecRetweet
 global.ExecTweet = ExecTweet
 global.ExecUnfollow = ExecUnfollow
-global.CountText = CountText
 global.TwitterHandlerTest = TwitterHandlerTest
+global.WriteWordCount = WriteWordCount


### PR DESCRIPTION
- ツイート本文列に変更があったとき、文字数カウント列に文字数を書き込む
- この機能を有効にするためには次のトリガーを登録する必要がある
    - 実行する関数を選択：WriteWordCount
    - イベントのソースを選択：スプレッドシートから
    - イベントの種類を選択：編集時
