### PR TITLE
NGワードを含むユーザをフォローしないようにする

### DIFF
--- a/gas/src/ExecTweet.js
+++ b/gas/src/ExecTweet.js
@@ -1,6 +1,6 @@
 import { GetAllData } from "./SpreadSheatHandler"
 import { CreateTweet, CreateReplyTweet } from "./TwitterHandler"
-import { GetOnOffSetting } from "./Utilities"
+import { GetCommonSetting } from "./Utilities"
 
 export function ExecTweet() {
   try {
@@ -12,7 +12,7 @@ export function ExecTweet() {
 
 function ExecTweetImpl() {
   // 全体設定でツイート機能がOFFになっている場合は何もしないで終了する
-  if (GetOnOffSetting("ツイート") == "OFF") {
+  if (GetCommonSetting("ツイート") == "OFF") {
     return
   }
 

--- a/gas/src/ExecUnfollow.js
+++ b/gas/src/ExecUnfollow.js
@@ -1,4 +1,4 @@
-import { GetOnOffSetting } from "./Utilities"
+import { GetCommonSetting } from "./Utilities"
 import { GetSelfFollowing, GetSelfFollower, UnfollowUser } from "./TwitterHandler"
 import { GetAllData } from "./SpreadSheatHandler"
 
@@ -12,7 +12,7 @@ export function ExecUnfollow() {
 
 function ExecUnfollowImpl() {
   // 全体設定でアンフォロー機能がOFFになっている場合は何もしないで終了する
-  if (GetOnOffSetting("アンフォロー") == "OFF") {
+  if (GetCommonSetting("アンフォロー") == "OFF") {
     return
   }
 

--- a/gas/src/TwitterHandler.js
+++ b/gas/src/TwitterHandler.js
@@ -4,7 +4,7 @@ export function TwitterHandlerTest() {
 }
 
 /**
- * キーワードを指定して最近投稿されたツイートをリストで取得する。リツイートは取得しない。
+ * キーワードを指定して最近投稿されたツイートをリストで取得する。
  * Rate Limit: 180/15[分]
  * ref: https://developer.twitter.com/en/docs/twitter-api/tweets/search/api-reference/get-tweets-search-recent
  */
@@ -41,7 +41,7 @@ export function GetUserInfo(userId) {
   const secrets = GetSecretsFromSpreadSheet()
   const service = GetService(secrets);
 
-  const userFields = "id,name,username,protected,public_metrics"
+  const userFields = "id,name,username,protected,public_metrics,description"
   const url = `https://api.twitter.com/2/users/${userId}?user.fields=${userFields}`
   const response = JSON.parse(service.fetch(url, { "method": "get" }));
   return {
@@ -50,7 +50,8 @@ export function GetUserInfo(userId) {
     "name": response["data"]["name"],
     "protected": response["data"]["protected"],
     "followersCount": response["data"]["public_metrics"]["followers_count"],
-    "followingCount": response["data"]["public_metrics"]["following_count"]
+    "followingCount": response["data"]["public_metrics"]["following_count"],
+    "description": response["data"]["description"]
   }
 }
 

--- a/gas/src/Utilities.js
+++ b/gas/src/Utilities.js
@@ -4,7 +4,7 @@ import twitter from "twitter-text"
 /**
  * 全体設定から各機能のON/OFFを取得する
  */
-export function GetOnOffSetting(key) {
+export function GetCommonSetting(key) {
   const settings = GetAllData("全体設定")
   const setting = settings.find(arr => arr[0] == key)
   return setting[1]
@@ -36,7 +36,7 @@ export function GetFunctionSettings(key) {
  * いいね・リツイート・フォローの情報をいろいろ加工して返す
  */
 export function GetFunctionInfo(key) {
-  const onOff = GetOnOffSetting(key)
+  const onOff = GetCommonSetting(key)
   const settings = GetFunctionSettings(key)
   const isOn = onOff == "ON"
   const rows = settings.map(setting => ({
@@ -48,6 +48,22 @@ export function GetFunctionInfo(key) {
     isOn,
     rows
   }
+}
+
+/**
+ * NGワードをリストで取得する。空欄の場合は無視する。
+ */
+export function GetNGWordList() {
+  const ngWordKeyList = ["NGワード1","NGワード2","NGワード3"]
+  var ngWordList = []
+  for (const ngWordKey of ngWordKeyList) {
+    const ngWord = GetCommonSetting(ngWordKey)
+    if (ngWord == "") {
+      continue
+    }
+    ngWordList.push(ngWord)
+  }
+  return ngWordList
 }
 
 /**


### PR DESCRIPTION
### 概要
掲題の通り。とりあえずフォロー機能にNGリスト考慮を追加した。
いいね機能、リツイート機能は別途プルリクを出す予定。

### 検証
* NGワードリストに「ひろゆき」を追加して、`FilterNgUserInfo()` で「ひろゆき」を名前もしくは説明文に含むユーザを除外できていることを確認

左がフィルターをかける前、右がフィルター後。「ひろゆき」を含むユーザが削除されていることがわかる。
![キャプチャ](https://user-images.githubusercontent.com/33785163/166132891-a7a8cb38-7ecd-4edc-91a9-5574aa5cb104.png)

