### PR TITLE
いいね時、リツイート時にもNGリストを考慮する

### DIFF
--- a/gas/src/ExecLike.js
+++ b/gas/src/ExecLike.js
@@ -1,5 +1,5 @@
 import { LikeTweet, SearchRecentTweetsWithoutRetweets } from "./TwitterHandler"
-import { GetFunctionInfo } from "./Utilities"
+import { GetFunctionInfo, GetNGWordList } from "./Utilities"
 
 export function ExecLike() {
   try {
@@ -18,6 +18,9 @@ function ExecLikeImpl() {
     return
   }
 
+  // NGワードのリストを取得
+  const ngWordList = GetNGWordList()
+
   // 各行に対していいねを実行する
   rows.forEach(({ isValid, query, count }) => {
     // アクティブ時間でなければ何もしないで終了する(未入力チェックも行う)
@@ -28,12 +31,31 @@ function ExecLikeImpl() {
     // キーワードをツイートしている人を取得する
     const tweets = SearchRecentTweetsWithoutRetweets(query)
 
+    // NGキーワードを含んでいるツイートを除外
+    const ngWordFilteredTweets = FilterNgTweet(tweets, ngWordList)
+
     // 1回あたりの実行数に絞る
-    const likeTargetTweetList = tweets.slice(0, count)
+    const likeTargetTweetList = ngWordFilteredTweets.slice(0, count)
 
     // 取得したツイートをいいねする
     for (const { tweetId } of likeTargetTweetList) {
       LikeTweet(tweetId)
     }
   })
+}
+
+/**
+ * ツイート本文にNGワードを含むツイートを除外する。
+ */
+function FilterNgTweet(tweets, ngWordList) {
+  console.log(tweets)
+  const filterNgTweet = (tweet, ngWordList) => {
+    for (const ngWord of ngWordList) {
+      if (tweet.text.indexOf(ngWord) != -1) {
+        return false
+      }
+    }
+    return true
+  }
+  return tweets.filter(tweet => filterNgTweet(tweet, ngWordList))
 }

--- a/gas/src/ExecLike.js
+++ b/gas/src/ExecLike.js
@@ -48,7 +48,6 @@ function ExecLikeImpl() {
  * ツイート本文にNGワードを含むツイートを除外する。
  */
 function FilterNgTweet(tweets, ngWordList) {
-  console.log(tweets)
   const filterNgTweet = (tweet, ngWordList) => {
     for (const ngWord of ngWordList) {
       if (tweet.text.indexOf(ngWord) != -1) {


### PR DESCRIPTION
前回の[プルリク](https://github.com/igarashi339/twitter-operation-automation/pull/11)でフォロー時にNGリストを考慮するようにしたのを、いいね時とリツイート時にも考慮するようにした。